### PR TITLE
fix(Android): Migrate NonNull annotation to AndroidX

### DIFF
--- a/android/src/main/java/com/wenkesj/voice/VoiceModule.java
+++ b/android/src/main/java/com/wenkesj/voice/VoiceModule.java
@@ -11,7 +11,7 @@ import android.speech.RecognitionListener;
 import android.speech.RecognitionService;
 import android.speech.RecognizerIntent;
 import android.speech.SpeechRecognizer;
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 import android.util.Log;
 
 import com.facebook.react.bridge.Arguments;


### PR DESCRIPTION
# Summary

On androidX the `android.support.annotation.NonNull` package does not exist, and this causes build error


## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |

## Checklist


- [x] I have tested this on a device and a simulator
- [ ] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
