### PR TITLE
Make content of buildscript optional

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -38,14 +38,16 @@ android {
 }
 
 buildscript {
-    repositories {
-        jcenter()
-    }
-    dependencies {
-        classpath 'com.android.tools.build:gradle:1.5.0'
+    if (project == rootProject) {
+        repositories {
+            jcenter()
+        }
+        dependencies {
+            classpath 'com.android.tools.build:gradle:1.5.0'
 
-        // NOTE: Do not place your application dependencies here; they belong
-        // in the individual module build.gradle files
+            // NOTE: Do not place your application dependencies here; they belong
+            // in the individual module build.gradle files
+        }
     }
 }
 


### PR DESCRIPTION
# Summary
Fix gradle build error where it can't find specified version of gradle.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |

## Checklist
- [X] I have tested this on a device and a simulator
