### PR TITLE
Recommend pod-install for setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,17 @@
 <p align="center">A speech-to-text library for <a href="https://reactnative.dev/">React Native.</a></p>
 
 ```sh
+yarn add @react-native-community/voice
+
+# or 
+
 npm i @react-native-community/voice --save
+```
+
+Link the iOS package
+
+```sh
+npx pod-install
 ```
 
 ## Table of contents


### PR DESCRIPTION
# Summary

We've been recommending devs use `npx pod-install` since it will attempt to install CocoaPods CLI if it's not available on the computer (cite [React Navigation setup guide](https://reactnavigation.org/docs/getting-started/#installing-dependencies-into-a-bare-react-native-project)). This has proved very useful for Expo users who are now migrating to the bare workflow and want to use community packages in their projects.

## Checklist

- [x] I have tested this on a device and a simulator
- [x] I added the documentation in `README.md`