### PR TITLE
fix(TypeScript): change type from string literal to string type

### DIFF
--- a/src/VoiceModuleTypes.ts
+++ b/src/VoiceModuleTypes.ts
@@ -41,7 +41,7 @@ export type SpeechResultsEvent = {
 
 export type SpeechErrorEvent = {
   error?: {
-    code?: 'string';
+    code?: string;
     message?: string;
   };
 };


### PR DESCRIPTION
# Summary

This PR changes the type for `code` on the error property of `SpeechErrorEvent` from the literal string `"string"` to the type string. Ideally, this should be an enumeration of possible values, but this change will at least allow users writing in TypeScript to avoid writing any unnecessary casting workarounds.

## Test Plan

No test plan as this is just a type definition change, but I'd be happy to write a test plan if the team thinks it's necessary.

### What's required for testing (prerequisites)?

An editor with TypeScript integrated or a TypeScript configured project.

### What are the steps to reproduce (after prerequisites)?

In a TypeScript file, try to compare the `e.error.code` property in the `onError` callback to an actual error code, `"recognition_fail"`, for example. You should see the following TS error: `This condition will always return 'false' since the types '"string" | undefined' and '"recognition_fail"' have no overlap.`

## Compatibility

N/A

## Checklist


- [ ] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [X] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
